### PR TITLE
Add python-pkg file

### DIFF
--- a/rosdep/sources.list.d/10-ascent.list
+++ b/rosdep/sources.list.d/10-ascent.list
@@ -1,2 +1,3 @@
 yaml https://artifactory.ascentrobotics.io/artifactory/rosdep_internal/external-pkg.yaml
 yaml https://artifactory.ascentrobotics.io/artifactory/rosdep_internal/ascent-internal-pkg.yaml
+yaml https://artifactory.ascentrobotics.io/artifactory/rosdep_internal/python-pkg.yaml


### PR DESCRIPTION
This file can be used to resolve ROS dependencies to python packages